### PR TITLE
add MatInputModule fixes #12

### DIFF
--- a/Frontend/src/app/pages/admin/add-category/add-category.component.html
+++ b/Frontend/src/app/pages/admin/add-category/add-category.component.html
@@ -17,7 +17,7 @@
                         name="Description" matInput>
                     </mat-form-field>
                     <div class="container text-center">
-                        <button mat-raised-button color="warn">add</button>
+                        <button mat-raised-button color="primary">add</button>
                     </div>
                 </form>
             </mat-card>

--- a/Frontend/src/app/pages/admin/add-category/add-category.component.ts
+++ b/Frontend/src/app/pages/admin/add-category/add-category.component.ts
@@ -10,12 +10,12 @@ import { FormsModule } from '@angular/forms';
 import { CategoryService } from '../../../services/category.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import Swal from 'sweetalert2';
-
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   selector: 'app-add-category',
   standalone: true,
-  imports: [MatButtonModule,MatCardModule,MatIconModule,MatListModule,RouterLink,CommonModule,MatFormFieldModule,FormsModule],
+  imports: [MatButtonModule,MatCardModule,MatIconModule,MatListModule,RouterLink,CommonModule,MatFormFieldModule,FormsModule,MatInputModule],
   templateUrl: './add-category.component.html',
   styleUrl: './add-category.component.css'
 })


### PR DESCRIPTION
MatInputModule is necessary to display components of mat-form-field and associated controls properly in angular material.